### PR TITLE
Add Git Host Substitution for GIT_HOST variable.

### DIFF
--- a/.modulemate/defaultConfig.json
+++ b/.modulemate/defaultConfig.json
@@ -16,7 +16,7 @@
             "steps": [
                 {
                     "type": "browser",
-                    "url": "https://{GIT_HOST}/{GIT_OWNER}/{GIT_REPOSITORY_NAME}/pull/{GIT_BRANCH_NAME}"
+                    "url": "https://{GIT_HOST_SUBSTITUTED}/{GIT_OWNER}/{GIT_REPOSITORY_NAME}/pull/{GIT_BRANCH_NAME}"
                 }
             ]
         },

--- a/README.md
+++ b/README.md
@@ -128,7 +128,8 @@ Opens the default browser to a specified URL.
 }
 ```
 
-- `url`: The url to open. You may use variables.
+- `url`: The url to open. You may use variables.<br>
+  **Tipp:** Prefer `GIT_HOST_SUBSTITUTED` over `GIT_HOST` for URLs, because some people may apply [Git-Host-Substitutions](https://github.com/xa17d/modulemate/pull/2#issue-2601844915).
 
 #### Gradle
 

--- a/modulemate/src/main/java/at/xa1/modulemate/Main.kt
+++ b/modulemate/src/main/java/at/xa1/modulemate/Main.kt
@@ -78,7 +78,7 @@ private fun modulemate(
         modules.applyFilter(PathPrefixFilter(prefixFilter))
     }
     val browser = ShellOpenBrowser(shell)
-    val defaultVariables = DefaultVariables.create(repository, modules)
+    val defaultVariables = DefaultVariables.create(repository, modules, configMerger.getVariablesConfig())
     val variables = CachedVariables(defaultVariables)
     val commandList = createCommandList(
         configMerger.getCommandsWithSource(),

--- a/modulemate/src/main/java/at/xa1/modulemate/command/variable/DefaultVariables.kt
+++ b/modulemate/src/main/java/at/xa1/modulemate/command/variable/DefaultVariables.kt
@@ -1,13 +1,23 @@
 package at.xa1.modulemate.command.variable
 
 import at.xa1.modulemate.Modulemate
+import at.xa1.modulemate.config.VariablesConfig
 import at.xa1.modulemate.git.GitRepository
 import at.xa1.modulemate.module.Modules
 
 object DefaultVariables {
-    fun create(repository: GitRepository, modules: Modules) = VariableSet().apply {
+    fun create(
+        repository: GitRepository,
+        modules: Modules,
+        variablesConfig: VariablesConfig
+    ) = VariableSet().apply {
         add(Variable("GIT_OWNER") { repository.getRemoteOrigin().owner })
         add(Variable("GIT_HOST") { repository.getRemoteOrigin().host })
+        add(
+            Variable("GIT_HOST_SUBSTITUTED") {
+                getHostSubstituted(variablesConfig, repository.getRemoteOrigin().host)
+            }
+        )
         add(Variable("GIT_REPOSITORY_NAME") { repository.getRemoteOrigin().repositoryName })
         add(Variable("GIT_BRANCH_NAME") { repository.getBranch() })
         add(

--- a/modulemate/src/main/java/at/xa1/modulemate/command/variable/GetHostSubstituted.kt
+++ b/modulemate/src/main/java/at/xa1/modulemate/command/variable/GetHostSubstituted.kt
@@ -1,0 +1,7 @@
+package at.xa1.modulemate.command.variable
+
+import at.xa1.modulemate.config.VariablesConfig
+
+internal fun getHostSubstituted(variablesConfig: VariablesConfig, host: String): String =
+    variablesConfig.gitHostSubstitutions
+        .find { substitution -> substitution.value.lowercase() == host.lowercase() }?.replacement ?: host

--- a/modulemate/src/main/java/at/xa1/modulemate/config/Config.kt
+++ b/modulemate/src/main/java/at/xa1/modulemate/config/Config.kt
@@ -8,6 +8,7 @@ import kotlinx.serialization.Serializable
 @Serializable
 data class Config(
     val version: String,
+    val variables: VariablesConfig = VariablesConfig(),
     val module: ModuleConfig = ModuleConfig(),
     val commands: List<Command> = emptyList()
 )
@@ -15,6 +16,17 @@ data class Config(
 @Serializable
 data class ModuleConfig(
     val classification: ModuleClassificationConfig? = null
+)
+
+@Serializable
+data class VariablesConfig(
+    val gitHostSubstitutions: List<GitHostSubstitutionConfig> = emptyList()
+)
+
+@Serializable
+data class GitHostSubstitutionConfig(
+    val value: String,
+    val replacement: String
 )
 
 @Serializable

--- a/modulemate/src/main/java/at/xa1/modulemate/config/ConfigMerger.kt
+++ b/modulemate/src/main/java/at/xa1/modulemate/config/ConfigMerger.kt
@@ -17,6 +17,14 @@ class ConfigMerger(
         }
     }
 
+    fun getVariablesConfig(): VariablesConfig {
+        val gitHostSubstitutions = configs.flatMap { it.config.variables.gitHostSubstitutions }
+
+        return VariablesConfig(
+            gitHostSubstitutions = gitHostSubstitutions
+        )
+    }
+
     private val configFiles: String
         get() = configs.mapNotNull { configSource ->
             when (val source = configSource.source) {

--- a/modulemate/src/test/kotlin/at/xa1/modulemate/command/variable/GetHostSubstitutedTest.kt
+++ b/modulemate/src/test/kotlin/at/xa1/modulemate/command/variable/GetHostSubstitutedTest.kt
@@ -1,0 +1,33 @@
+package at.xa1.modulemate.command.variable
+
+import at.xa1.modulemate.config.GitHostSubstitutionConfig
+import at.xa1.modulemate.config.VariablesConfig
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class GetHostSubstitutedTest {
+    @Test
+    fun `hosts in config are replaced, hosts not in config are unchanged`() {
+        val config = VariablesConfig(
+            gitHostSubstitutions = listOf(
+                GitHostSubstitutionConfig(value = "localhost", replacement = "example.com"),
+                GitHostSubstitutionConfig(value = "github.com-ACME", replacement = "github.com")
+            )
+        )
+
+        assertEquals("example.com", getHostSubstituted(config, "localhost")) // replaced
+        assertEquals("github.com", getHostSubstituted(config, "github.com-ACME")) // replaced
+        assertEquals("xa1.at", getHostSubstituted(config, "xa1.at")) // unchanged
+    }
+
+    @Test
+    fun `substitution is not case sensitive`() {
+        val config = VariablesConfig(
+            gitHostSubstitutions = listOf(
+                GitHostSubstitutionConfig(value = "github.com-ACME", replacement = "github.com")
+            )
+        )
+
+        assertEquals("github.com", getHostSubstituted(config, "GitHub.com-Acme"))
+    }
+}


### PR DESCRIPTION
People with multiple GitHub accounts (or other Git providers) might use custom hosts to distinguish their SSH keys:

```
git@github.com-personal:xa17d/myrepo.git
git@github.com-work:some-company/otherrepo.git
```

Also see: https://theboreddev.com/use-multiple-ssh-keys-different-git-accounts/

Since this breaks steps like:
```
{
    "type": "browser",
    "url": "https://{GIT_HOST}/{GIT_OWNER}/{GIT_REPOSITORY_NAME}/pull/{GIT_BRANCH_NAME}"
}
```
_(`GIT_HOST` would resolve to `github.com-personal` or `github.com-work`, which are not valid HTTPS hosts)._

This PR adds the option to configure `GIT_HOST`-substitutions using the config:
```json
{
    "variables": {
        "gitHostSubstitutions": [
            {
                "value": "github.com-private",
                "replacement": "github.com"
            },
            {
                "value": "github.com-work",
                "replacement": "github.com"
            }
        ]
    },
}
```

The `GIT_HOST` variable remains unchanged, but substitutions are applied to the `GIT_HOST_SUBSTITUTED` variable.